### PR TITLE
Erosita cleaning bug fix

### DIFF
--- a/daxa/process/erosita/_common.py
+++ b/daxa/process/erosita/_common.py
@@ -103,6 +103,27 @@ def _is_valid_flag(flag):
         # If the flag is invalid then a ValueError is thrown
         return False
 
+def _make_flagsel_keword(flag, invert=True):
+    """
+    This function is to be called within the cleaned_evt_lists function to generate the correct
+    header keyword based on the user's input eSASS flag. This is a workaround a bug within eSASS.
+
+    :param flag Flag: The user input of the flag parameter in the cleaned_evt_list function.
+        This may be in hexidecimal or its equivalent decimal format, both are accepted by evtool.
+    """
+
+    #TODO I think that the pattern selection might effect the FLAGSEL keyword - need to check
+
+    if invert:
+        value = _eSASS_Flag(flag).value
+    
+    else:
+        # This returns a flag containing all the bits apart from those specified by the user
+        value = ~_eSASS_Flag(flag).value
+
+    return value
+
+
 
 def _esass_process_setup(obs_archive: Archive) -> bool:
     """

--- a/daxa/process/erosita/assemble.py
+++ b/daxa/process/erosita/assemble.py
@@ -81,7 +81,7 @@ def cleaned_evt_lists(obs_archive: Archive, lo_en: Quantity = Quantity(0.2, 'keV
 
     # Checking user's lo_en and hi_en inputs are in the valid energy range for eROSITA
     if (lo_en < Quantity(200, 'eV') or lo_en > Quantity(10000, 'eV')) or \
-        (hi_en < Quantity(200, 'eV') or hi_en > Quantity(10000, 'eV')):
+       (hi_en < Quantity(200, 'eV') or hi_en > Quantity(10000, 'eV')):
         raise ValueError("The lo_en and hi_en value must be between 0.2 keV and 10 keV.")
 
     # The eSASS software has a bug when the user specifies the flag inversion parameter
@@ -89,7 +89,7 @@ def cleaned_evt_lists(obs_archive: Archive, lo_en: Quantity = Quantity(0.2, 'keV
     if flag != 0xc0000000:
         raise NotImplementedError("Daxa currently doesn't support flag selection due to a bug "
                                   "within the eSASS software.")
-    if flag_invert != True:
+    if not flag_invert:
         raise NotImplementedError("Daxa currently doesn't support flag selection due to a bug "
                                   "within the eSASS software.")
         

--- a/daxa/process/erosita/assemble.py
+++ b/daxa/process/erosita/assemble.py
@@ -87,7 +87,7 @@ def cleaned_evt_lists(obs_archive: Archive, lo_en: Quantity = Quantity(0.2, 'keV
     # The eSASS software has a bug when the user specifies the flag inversion parameter
     # so for the moment we wont let the user chose the flag
     if flag != 0xc0000000:
-        raise NotImplementedError("Daxa currently doesn't support flag selection due to a bug "
+        raise NotImplementedError("DAXA currently doesn't support flag selection due to a bug "
                                   "within the eSASS software.")
     # Checking user has input the flag parameter as an integer
     #if not isinstance(flag, int):
@@ -99,7 +99,7 @@ def cleaned_evt_lists(obs_archive: Archive, lo_en: Quantity = Quantity(0.2, 'keV
     #                    " for valid flags.".format(flag))
     
     if not flag_invert:
-        raise NotImplementedError("Daxa currently doesn't support flag selection due to a bug "
+        raise NotImplementedError("DAXA currently doesn't support flag selection due to a bug "
                                   "within the eSASS software.")
         
     # Checking user has input flag_invert as a boolean

--- a/daxa/process/erosita/assemble.py
+++ b/daxa/process/erosita/assemble.py
@@ -89,6 +89,15 @@ def cleaned_evt_lists(obs_archive: Archive, lo_en: Quantity = Quantity(0.2, 'keV
     if flag != 0xc0000000:
         raise NotImplementedError("Daxa currently doesn't support flag selection due to a bug "
                                   "within the eSASS software.")
+    # Checking user has input the flag parameter as an integer
+    #if not isinstance(flag, int):
+    #    raise TypeError("The flag parameter must be an integer.")
+
+    # Checking the input is a valid hexidecimal number
+    #if not _is_valid_flag(flag):
+    #    raise ValueError("{} is not a valid eSASS flag, see the eROSITA website"
+    #                    " for valid flags.".format(flag))
+    
     if not flag_invert:
         raise NotImplementedError("Daxa currently doesn't support flag selection due to a bug "
                                   "within the eSASS software.")
@@ -109,9 +118,16 @@ def cleaned_evt_lists(obs_archive: Archive, lo_en: Quantity = Quantity(0.2, 'keV
     lo_en = lo_en.value
     hi_en = hi_en.value
 
+    #if flag_invert:
+    #    flag_invert = 'yes'
+    #else:
+    #    flag_invert = 'no'
+
     # Define the form of the evtool command that must be run for event list filtering to take place
     evtool_cmd = "cd {d}; evtool eventfiles={ef} gti=FLAREGTI outfile={of} pattern={p} " \
                  "emin={emin} emax={emax}; mv {of} {fep}; rm -r {d}"
+    #evtool_cmd = "cd {d}; evtool eventfiles={ef} gti=FLAREGTI outfile={of} pattern={p} " \
+    #             " flag={f} flag_invert={fi} emin={emin} emax={emax}; mv {of} {fep}; rm -r {d}"
 
     # Sets up storage dictionaries for bash commands, final file paths (to check they exist at the end), and any
     #  extra information that might be useful to provide to the next step in the generation process


### PR DESCRIPTION
This addresses issue #285 . The FLAGSEL keyword was being written incorrectly when the user was selecting a flag/ flag_invert parameter.

Within this branch is a function that could be used to write this FLAGSEL keyword, if we ever get all the definitions of the different flag bits that eSASS uses, but until then, this function is useless.


This should be tested before being merged into main! Apologies I havent had the chance to yet!