### PR TITLE
Aligns mission classes with new API changes from HEASARC Browse that broke master table fetching

### DIFF
--- a/daxa/mission/asca.py
+++ b/daxa/mission/asca.py
@@ -248,6 +248,10 @@ class ASCA(BaseMission):
         #  like we do with some other missions
         which_cols = ['RA', 'DEC', 'SEQUENCE_NUMBER', 'TIME', 'END_TIME', 'Subject_Category', 'Status', 'GIS_EXPOSURE',
                       'SIS_EXPOSURE']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)

--- a/daxa/mission/chandra.py
+++ b/daxa/mission/chandra.py
@@ -317,6 +317,10 @@ class Chandra(BaseMission):
         #  (https://heasarc.gsfc.nasa.gov/W3Browse/all/chanmaster.html)
         which_cols = ['RA', 'DEC', 'TIME', 'OBSID', 'STATUS', 'DETECTOR', 'GRATING', 'EXPOSURE', 'TYPE', 'DATA_MODE',
                       'CLASS', 'PUBLIC_DATE']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are some more, but I
         #  curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)

--- a/daxa/mission/integral.py
+++ b/daxa/mission/integral.py
@@ -245,6 +245,10 @@ class INTEGRALPointed(BaseMission):
         #  instrument - but that would be a LOT of columns
         which_cols = ['RA', 'DEC', 'ScW_ID', 'Start_Date', 'End_Date', 'SPI_mode', 'Good_JEMX1', 'Good_JEMX2',
                       'Good_ISGRI', 'Good_PICSIT', 'Good_SPI', 'Data_In_HEASARC', 'ScW_Ver']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # Might add these at some point:
         # Obs_Type, 'JEMX1_mode', 'JEMX2_mode', 'IBIS_Mode'
 

--- a/daxa/mission/nustar.py
+++ b/daxa/mission/nustar.py
@@ -231,6 +231,10 @@ class NuSTARPointed(BaseMission):
         which_cols = ['RA', 'DEC', 'TIME', 'OBSID', 'STATUS', 'EXPOSURE_A', 'OBSERVATION_MODE', 'PUBLIC_DATE',
                       'ISSUE_FLAG', 'END_TIME', 'EXPOSURE_B', 'INSTRUMENT_MODE', 'NUPSDOUT', 'ONTIME_A', 'ONTIME_B',
                       'SPACECRAFT_MODE', 'SUBJECT_CATEGORY', 'OBS_TYPE', 'NAME']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)

--- a/daxa/mission/rosat.py
+++ b/daxa/mission/rosat.py
@@ -321,6 +321,10 @@ class ROSATPointed(BaseMission):
         #  (https://heasarc.gsfc.nasa.gov/W3Browse/rosat/rosmaster.html)
         which_cols = ['RA', 'DEC', 'Seq_ID', 'Start_Time', 'End_Time', 'Exposure', 'FITS_Type', 'Instrument',
                       'Filter', 'Proc_Rev', 'Subj_Cat', 'Name', 'Site']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)
@@ -832,6 +836,10 @@ class ROSATAllSky(BaseMission):
         #  in 'normal' mode, just so I can exclude those observations because frankly I don't know the difference
         # SPACECRAFT_MODE is acquired because the 'STELLAR' mode might not be suitable for science so may be excluded
         which_cols = ['RA', 'DEC', 'Seq_ID', 'Start_Date', 'End_Date', 'Exposure']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)

--- a/daxa/mission/suzaku.py
+++ b/daxa/mission/suzaku.py
@@ -231,6 +231,10 @@ class Suzaku(BaseMission):
         which_cols = ['RA', 'DEC', 'OBSID', 'TIME', 'STOP_TIME', 'Category_Code',
                       'XIS0_Expo', 'XIS0_Num_Modes', 'XIS1_Expo', 'XIS1_Num_Modes', 'XIS2_Expo', 'XIS2_Num_Modes',
                       'XIS3_Expo', 'XIS3_Num_Modes']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)

--- a/daxa/mission/swift.py
+++ b/daxa/mission/swift.py
@@ -248,6 +248,10 @@ class Swift(BaseMission):
         #  instrument - but that would be a LOT of columns
         which_cols = ['RA', 'DEC', 'Roll_Angle', 'ObsID', 'Start_Time', 'Stop_Time', 'XRT_Exposure', 'UVOT_Exposure',
                       'BAT_Exposure']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)

--- a/daxa/mission/xmm.py
+++ b/daxa/mission/xmm.py
@@ -253,6 +253,9 @@ class XMMPointed(BaseMission):
             #  (https://heasarc.gsfc.nasa.gov/W3Browse/xmm-newton/xmmmaster.html)
             which_cols = ['RA', 'DEC', 'TIME', 'END_TIME', 'OBSID', 'STATUS', 'DURATION', 'PUBLIC_DATE',
                           'DATA_IN_HEASARC', 'XMM_REVOLUTION']
+            # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+            #  fetching the obs tables soon (famous last words).
+            which_cols = [en.lower() for en in which_cols]
 
             # This is what will be put into the URL to retrieve just those data fields - there are quite a few more
             #  but I curated it to only those I think might be useful for DAXA

--- a/daxa/mission/xrism.py
+++ b/daxa/mission/xrism.py
@@ -241,6 +241,10 @@ class XRISMPointed(BaseMission):
         #  (https://heasarc.gsfc.nasa.gov/W3Browse/xrism/xrismmastr.html)
         which_cols = ['RA', 'DEC', 'OBSID', 'TIME', 'END_TIME', 'Duration', 'Exposure', 'Xtd_Expo', 'Subject_Category',
                       'Rsl_Datamode', 'Xtd_Datamode1', 'Xtd_Datamode2', 'Xtd_Dataclas1', 'Xtd_Dataclas2', 'Public_Date']
+        # This is a quick fix for issue 438, as this whole method will be replaced with a different way of
+        #  fetching the obs tables soon (famous last words).
+        which_cols = [en.lower() for en in which_cols]
+
         # This is what will be put into the URL to retrieve just those data fields - there are quite a few more,
         #  but I curated it to only those I think might be useful for DAXA
         fields = '&Fields=' + '&varon=' + '&varon='.join(which_cols)


### PR DESCRIPTION
This fix restores functionality to the majority of mission classes - any version of DAXA prior to this will not be able to fetch those tables now. We aim to replace this fragile dependance on Browse with Astroquery soon.